### PR TITLE
Remove undefined cmath_tanh.

### DIFF
--- a/ttim/aquifer.py
+++ b/ttim/aquifer.py
@@ -105,11 +105,8 @@ class AquiferData:
         b[~small] = sqrtpSc[~small] * 2.0 * np.exp(-sqrtpSc[~small]) / \
                     (1.0 - np.exp(-2.0*sqrtpSc[~small]))
         if (self.topboundary[:3] == 'sem') or (self.topboundary[:3] == 'lea'):
-            if abs(sqrtpSc[0]) < 200:
-                dzero = sqrtpSc[0] * np.tanh(sqrtpSc[0])
-            else:
-                # Bug in complex tanh in numpy
-                dzero = sqrtpSc[0] * cmath_tanh(sqrtpSc[0])  
+            dzero = sqrtpSc[0] * np.tanh(sqrtpSc[0])
+
         d0 = p / self.D
         if B is not None:
             d0 = d0 * B  # B is vector of load efficiency paramters


### PR DESCRIPTION
Some testing also shows that numpy.tanh and cmath.tanh give the same answers now (as far as I can tell), no longer requiring special casing for abs(sqrtpSc[0]) < 200.

To illustrate:

```python
import cmath
import numpy as np


a = np.arange(0.01, 200.0, 0.1)
b = np.tanh(a)
c = np.array([cmath.tanh(e) for e in a])

assert np.allclose(b, c.real)
```

This gets rid of a bug where certain resistance or storage values would result in an error, because ``cmath_tanh`` is not defined anywhere currently.