### PR TITLE
Bugfix in mid definition

### DIFF
--- a/docs/03examples/watex_example.ipynb
+++ b/docs/03examples/watex_example.ipynb
@@ -323,7 +323,7 @@
     "    where=\"post\",\n",
     "    label=\"shift -1\",\n",
     ")\n",
-    "mid = (data.loc[:, \"rivier\"] + data.loc[:, \"rivier\"].shift(-1).values).divide(2)\n",
+    "mid = (data_norm.loc[:, \"rivier\"] + data_norm.loc[:, \"rivier\"].shift(-1).values).divide(2)\n",
     "plt.step(\n",
     "    mid.loc[:1].index, mid.loc[:1], where=\"post\", label=\"midpoint\", color=\"k\", lw=1.0\n",
     ")\n",


### PR DESCRIPTION
Calculation of 'mid' should point to 'data_norm' instead of 'data'.