### PR TITLE
Bugfix for use of old layer definition in 'fit' function

### DIFF
--- a/ttim/fit.py
+++ b/ttim/fit.py
@@ -96,7 +96,7 @@ class Calibrate:
                 from_lay = int(layers_from_name[0])
                 to_lay = from_lay + 1
             elif len(layers_from_name) == 2:
-                from_lay, to_lay = layers_from_name
+                from_lay, to_lay = map(int, layers_from_name)
 
         # get aquifer information and create list if necessary
         if inhoms is None:


### PR DESCRIPTION
I used the code: `ca.set_parameter(name="kaq0_2", initial=10)`, and the original code extracted the numbers 0 and 2 as layer numbers, but these were strings instead of integers.

Fixed with this commit.