### PR TITLE
Check topboundary values

### DIFF
--- a/ttim/aquifer.py
+++ b/ttim/aquifer.py
@@ -58,6 +58,7 @@ class AquiferData:
         self.model3d = model3d
         if self.model3d:
             assert self.kzoverkh is not None, "model3d specified without kzoverkh"
+            assert self.topboundary != 'con', "Error: For Model3D, only 'confined' topboundary is currently implemented"
         # self.D = self.T / self.Saq
         self.area = 1e200  # Smaller than default of ml.aq so that inhom is found
         self.name = name
@@ -71,6 +72,7 @@ class AquiferData:
             topbound = "semi-confined"
         else:
             topbound = "unknown"  # should not happen
+            raise ValueError("You specified an invalid topboundary. Use 'confined', 'semi' or 'leaky'.")
         return f"Inhom Aquifer: {self.naq} aquifer(s) with {topbound} top boundary"
 
     def initialize(self):

--- a/ttim/aquifer.py
+++ b/ttim/aquifer.py
@@ -58,7 +58,9 @@ class AquiferData:
         self.model3d = model3d
         if self.model3d:
             assert self.kzoverkh is not None, "model3d specified without kzoverkh"
-            assert self.topboundary != 'con', "Error: For Model3D, only 'confined' topboundary is currently implemented"
+            assert (
+                self.topboundary != "con"
+            ), "Error: For Model3D, only 'confined' topboundary is currently implemented"
         # self.D = self.T / self.Saq
         self.area = 1e200  # Smaller than default of ml.aq so that inhom is found
         self.name = name
@@ -72,7 +74,9 @@ class AquiferData:
             topbound = "semi-confined"
         else:
             topbound = "unknown"  # should not happen
-            raise ValueError("You specified an invalid topboundary. Use 'confined', 'semi' or 'leaky'.")
+            raise ValueError(
+                "You specified an invalid topboundary. Use 'confined', 'semi' or 'leaky'."
+            )
         return f"Inhom Aquifer: {self.naq} aquifer(s) with {topbound} top boundary"
 
     def initialize(self):


### PR DESCRIPTION
According to the [documentation ](https://github.com/mbakker7/ttim/blob/4af45958a5f3e64f031f1a131dc9f7f5adbd758d/ttim/model.py#L812-L815) of TTim for Model3D only 'confined' toplayer is implemented. Added a check on this.

And (more general) raise a ValueError when topboundary value is unknown.