### PR TITLE
Bugfix Linedoublet1d plot

### DIFF
--- a/ttim/linedoublet1d.py
+++ b/ttim/linedoublet1d.py
@@ -136,10 +136,11 @@ class LineDoublet1DBase(Element):
     def plot(self, ax=None):
         if ax is None:
             _, ax = plt.subplots()
+        aq = self.model.aq.find_aquifer_data(self.xld, 0.0)
         for ilay in self.layers:
             ax.plot(
                 [self.xld, self.xld],
-                [self.model.aq.zaqtop[ilay], self.model.aq.zaqbot[ilay]],
+                [aq.zaqtop[ilay], aq.zaqbot[ilay]],
                 "k-",
             )
 


### PR DESCRIPTION
Modified code of LineDoublet1D in order to fix plotting. Made analogous to the code of the Linesink1D: https://github.com/mbakker7/ttim/blob/4af45958a5f3e64f031f1a131dc9f7f5adbd758d/ttim/linesink1d.py#L156-L165

_(Note: even after this modification the LineDoublet is only drawn in the aquifer layers and not in the aquitard part. As is the case for the LineSink1D)._