### PR TITLE
125 calibration check for duplicate parameter names

### DIFF
--- a/ttim/fit.py
+++ b/ttim/fit.py
@@ -140,7 +140,7 @@ class Calibrate:
         if inhoms is None:
             pname = f"{name}_{from_lay}_{to_lay}"
         else:
-            pname = f"{name}_{from_lay}_{to_lay}{'_'.join([iaq.name for iaq in aq])}"
+            pname = f"{name}_{from_lay}_{to_lay}_{'_'.join([iaq.name for iaq in aq])}"
         self.parameters.loc[pname] = {
             "layers": layers,
             "optimal": float(initial),

--- a/ttim/fit.py
+++ b/ttim/fit.py
@@ -138,9 +138,9 @@ class Calibrate:
             return
 
         if inhoms is None:
-            pname = name
+            pname = f"{name}_{from_lay}_{to_lay}"
         else:
-            pname = f"{name}_{'_'.join([iaq.name for iaq in aq])}"
+            pname = f"{name}_{from_lay}_{to_lay}{'_'.join([iaq.name for iaq in aq])}"
         self.parameters.loc[pname] = {
             "layers": layers,
             "optimal": float(initial),


### PR DESCRIPTION
Add layer numbers to parameter names. This is clearer and avoids overwriting parameters with the same name but different layers.