### PR TITLE
Fix xsection plot for params=True and labels=False

### DIFF
--- a/ttim/plots.py
+++ b/ttim/plots.py
@@ -115,7 +115,7 @@ class PlotTtim:
             r = 1.0
 
         # get values for layer and aquifer numbering
-        if (labels or params):
+        if labels or params:
             lli = 1 if self._ml.aq.topboundary == "con" else 0
             aqi = 0
         else:


### PR DESCRIPTION
Before this fix, the following combination of `params=True` and `labels=False` leads to an error:

```
import ttim
ml = ttim.Model3D(
        kaq=[10, 0.025, 30, 0.01, 20],
        z=[0, -5, -10, -20, -25, -35],
        kzoverkh=0.1,
        Saq=1e-4,
        tmin=0.01,
        tmax=10,
    )
ml.plots.xsection(params=True, labels=False)
```

Fixed by this change.